### PR TITLE
Fix the way infrastructure is run

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -565,7 +565,11 @@ func (r *TestRunner) runInfrastructure(ctx context.Context) (err error) {
 		paths := collectDockerComposeFiles(infraConfigs...)
 
 		logger.Info("Running infrastructure", "name", k, "log-path", logPath)
-		err = r.dockerComposeUpWait(ctx, logger, paths, r.infrastructureContainers, logPath)
+		containers, err := findContainerNames(ctx, paths)
+		if err != nil {
+			return fmt.Errorf("failed finding container names for paths %v: %w", paths, err)
+		}
+		err = r.dockerComposeUpWait(ctx, logger, paths, containers, logPath)
 		if err != nil {
 			return fmt.Errorf("failed to start infrastructure: %w", err)
 		}


### PR DESCRIPTION
### Description

Previously, `dockerComposeUpWait` was called with a single Docker compose file, but was given the list of **all** containers for which the method would be waiting. This resulted in the method actually never returning, and only the first infrastructure file would be run.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/benchi/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
